### PR TITLE
Toolbar group button text

### DIFF
--- a/Pápia/ToolbarButtonComponent.swift
+++ b/Pápia/ToolbarButtonComponent.swift
@@ -73,7 +73,7 @@ struct PlatformButton: UIViewRepresentable {
     func makeUIView(context: Context) -> UIButton {
         let button = UIButton(type: .system)
         button.setTitle(label, for: .normal)
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
+        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         button.setContentHuggingPriority(.required, for: .horizontal)
         button.setContentHuggingPriority(.required, for: .vertical)
         button.configuration = .glass()
@@ -140,7 +140,7 @@ struct PlatformButton: NSViewRepresentable {
         let button = NSButton(title: label, target: context.coordinator, action: #selector(Coordinator.handleTap))
         button.bezelStyle = .inline
         button.isBordered = false
-        button.font = NSFont.preferredFont(forTextStyle: .callout)
+        button.font = NSFont.preferredFont(forTextStyle: .body)
         button.setContentHuggingPriority(.required, for: .horizontal)
         button.setContentHuggingPriority(.required, for: .vertical)
         


### PR DESCRIPTION
Increase toolbar button text size by changing font style from `.callout` to `.body`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6a5d03c-8496-4990-b4a6-dbd648cc5c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6a5d03c-8496-4990-b4a6-dbd648cc5c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

