### PR TITLE
History view settings button

### DIFF
--- a/Pápia/ContentView.swift
+++ b/Pápia/ContentView.swift
@@ -78,7 +78,8 @@ struct ContentView: View {
                     searchResultsCount: model.searchResults.count,
                     searchText: model.searchText,
                     searchIsFocused: $searchIsFocused,
-                    searchHistoryItems: []
+                    searchHistoryItems: [],
+                    showSettings: $showSettings
                 )
             }
         }
@@ -113,7 +114,8 @@ struct ContentView: View {
                 searchResultsCount: model.searchResults.count,
                 searchText: model.searchText,
                 searchIsFocused: $searchIsFocused,
-                searchHistoryItems: []
+                searchHistoryItems: [],
+                showSettings: $showSettings
             )
         )
         .toolbar {
@@ -190,7 +192,8 @@ struct ContentView: View {
                         searchResultsCount: model.searchResults.count,
                         searchText: model.searchText,
                         searchIsFocused: $searchIsFocused,
-                        searchHistoryItems: state.navigationHistory
+                        searchHistoryItems: state.navigationHistory,
+                        showSettings: $showSettings
                     )
                 )
                 .contentMargins(.top, 60, for: .scrollContent)

--- a/Pápia/SearchContentUnavailableView.swift
+++ b/Pápia/SearchContentUnavailableView.swift
@@ -1,6 +1,6 @@
 //
 //  SearchContentUnavailableView.swift
-//  Pápia
+//  Pápia
 //
 //  Created by Stef Kors on 30/04/2024.
 //
@@ -9,13 +9,14 @@ import SwiftUI
 import SwiftData
 
 extension View {
-    func searchContentUnavailableView(searchResultsCount: Int, searchText: String, searchIsFocused: FocusState<Bool>.Binding, searchHistoryItems: [DataMuseWord]) -> some View {
+    func searchContentUnavailableView(searchResultsCount: Int, searchText: String, searchIsFocused: FocusState<Bool>.Binding, searchHistoryItems: [DataMuseWord], showSettings: Binding<Bool>) -> some View {
         modifier(
             SearchContentUnavailableViewModifier(
                 searchResultsCount: searchResultsCount,
                 searchText: searchText,
                 searchIsFocused: searchIsFocused,
-                searchHistoryItems: searchHistoryItems
+                searchHistoryItems: searchHistoryItems,
+                showSettings: showSettings
             )
         )
     }
@@ -26,6 +27,7 @@ struct SearchContentUnavailableViewModifier: ViewModifier {
     let searchText: String
     let searchIsFocused: FocusState<Bool>.Binding
     let searchHistoryItems: [DataMuseWord]
+    @Binding var showSettings: Bool
 
     func body(content: Content) -> some View {
         content
@@ -34,7 +36,8 @@ struct SearchContentUnavailableViewModifier: ViewModifier {
                     searchResultsCount: searchResultsCount,
                     searchText: searchText,
                     searchIsFocused: searchIsFocused,
-                    searchHistoryItems: searchHistoryItems
+                    searchHistoryItems: searchHistoryItems,
+                    showSettings: $showSettings
                 )
             }
     }
@@ -47,6 +50,7 @@ struct SearchContentUnavailableView: View {
     let searchText: String
     let searchIsFocused: FocusState<Bool>.Binding
     let searchHistoryItems: [DataMuseWord]
+    @Binding var showSettings: Bool
 
     @State private var isDragging = false
     @State private var ignoreDragging = false
@@ -94,7 +98,7 @@ struct SearchContentUnavailableView: View {
                 Group {
                     if #available(iOS 17.0, *) {
                         ContentUnavailableView {
-                            Label("Search Pápia...", systemImage: "bird.fill")
+                            Label("Search Pápia...", systemImage: "bird.fill")
                         } description: {
                             Text("Start your search, then filter your query")
                         } actions: {
@@ -107,10 +111,17 @@ struct SearchContentUnavailableView: View {
                                     .buttonStyle(NavigationButtonStyle())
                                 }
                             }
+                            
+                            Button {
+                                showSettings = true
+                            } label: {
+                                Label("Settings", systemImage: "gearshape")
+                            }
+                            .buttonStyle(.bordered)
                         }
                     } else {
                         VStack {
-                            Label("Search Pápia...", systemImage: "bird.fill")
+                            Label("Search Pápia...", systemImage: "bird.fill")
                             Text("Start your search, then filter your query")
                         }
                     }

--- a/Pápia/iOSContentViewAdjustmentsView.swift
+++ b/Pápia/iOSContentViewAdjustmentsView.swift
@@ -13,6 +13,7 @@ struct iOSContentViewAdjustmentsView: ViewModifier {
     let searchText: String
     let searchIsFocused: FocusState<Bool>.Binding
     let searchHistoryItems: [DataMuseWord]
+    @Binding var showSettings: Bool
     func body(content: Content) -> some View {
 #if os(macOS)
         content
@@ -23,7 +24,8 @@ struct iOSContentViewAdjustmentsView: ViewModifier {
                 searchResultsCount: searchResultsCount,
                 searchText: searchText,
                 searchIsFocused: searchIsFocused,
-                searchHistoryItems: searchHistoryItems
+                searchHistoryItems: searchHistoryItems,
+                showSettings: $showSettings
             )
 #endif
     }


### PR DESCRIPTION
Add a secondary "Settings" button to the content unavailable view to provide quick access to the settings sheet.

---
<a href="https://cursor.com/background-agent?bcId=bc-b094239f-5760-4682-9cc4-db0f85aa2446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b094239f-5760-4682-9cc4-db0f85aa2446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

