### PR TITLE
Settings dictionary toggles

### DIFF
--- a/Pápia/SettingsView.swift
+++ b/Pápia/SettingsView.swift
@@ -1,6 +1,6 @@
 //
 //  SettingsView.swift
-//  Pápia
+//  Pápia
 //
 //  Created by Cursor on 29/09/2025.
 //
@@ -8,28 +8,97 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("enable-wordle-dictionary") private var enableWordleDictionary: Bool = true
+    @AppStorage("enable-bongo-dictionary") private var enableBongoDictionary: Bool = true
     @AppStorage("enable-scrabble-english") private var enableScrabbleEnglish: Bool = true
-    @AppStorage("enable-scrabble-other") private var enableScrabbleOtherLanguages: Bool = false
+    @AppStorage("enable-wordle-dictionary") private var enableWordleDictionary: Bool = true
 
     var body: some View {
         Form {
-            Section("Wordle") {
-                Toggle("Enable Wordle dictionary", isOn: $enableWordleDictionary)
+            Section {
+                DictionaryToggleRow(
+                    imageName: "Bongo",
+                    title: "Bongo Dictionary",
+                    description: "Common words used in the Bongo word game",
+                    isEnabled: $enableBongoDictionary
+                )
+            } header: {
+                DictionarySectionHeader(imageName: "Bongo", title: "Bongo")
             }
 
-            Section("Scrabble") {
-                Toggle("Enable Scrabble English dictionaries", isOn: $enableScrabbleEnglish)
-                Toggle("Enable Scrabble other languages", isOn: $enableScrabbleOtherLanguages)
+            Section {
+                DictionaryToggleRow(
+                    imageName: "Scrabble",
+                    title: "Scrabble English Dictionary",
+                    description: "Official Scrabble word list (SOWPODS)",
+                    isEnabled: $enableScrabbleEnglish
+                )
+            } header: {
+                DictionarySectionHeader(imageName: "Scrabble", title: "Scrabble")
+            }
+
+            Section {
+                DictionaryToggleRow(
+                    imageName: "Wordle",
+                    title: "Wordle Dictionary",
+                    description: "5-letter words used in Wordle",
+                    isEnabled: $enableWordleDictionary
+                )
+            } header: {
+                DictionarySectionHeader(imageName: "Wordle", title: "Wordle")
             }
         }
         .navigationTitle("Settings")
     }
 }
 
-#Preview {
-    SettingsView()
+// MARK: - Dictionary Toggle Row
+
+struct DictionaryToggleRow: View {
+    let imageName: String
+    let title: String
+    let description: String
+    @Binding var isEnabled: Bool
+    
+    var body: some View {
+        Toggle(isOn: $isEnabled) {
+            HStack(spacing: 12) {
+                Image(imageName)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 32, height: 32)
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body)
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .tint(.accentColor)
+    }
 }
 
+// MARK: - Dictionary Section Header
 
+struct DictionarySectionHeader: View {
+    let imageName: String
+    let title: String
+    
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 16, height: 16)
+            Text(title)
+        }
+    }
+}
 
+#Preview {
+    NavigationStack {
+        SettingsView()
+    }
+}


### PR DESCRIPTION
Add graphics and toggles to the settings view for Bongo, Scrabble, and Wordle dictionaries.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fb55c37-0861-4ea8-a071-10cbfbd3b7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3fb55c37-0861-4ea8-a071-10cbfbd3b7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

