### PR TITLE
macOS build issues

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,81 @@
+# Pápia Project - Cursor Rules
+
+## Cross-Platform Build Requirements
+
+This is a SwiftUI app that targets **both iOS and macOS**. All code changes must compile and work correctly on both platforms.
+
+### Platform-Specific Code Guidelines
+
+1. **Always check both platforms when modifying code**
+   - When editing any Swift file, verify the code compiles for both iOS and macOS
+   - Pay special attention to `#if os(macOS)` and `#if os(iOS)` conditional compilation blocks
+
+2. **@FocusState and platform-specific properties**
+   - This codebase uses separate `@FocusState` properties for each platform:
+     - `searchFocused` - Used in macOS code blocks (`#if os(macOS)`)
+     - `searchIsFocused` - Used in iOS code blocks (`#if os(iOS)`)
+   - Never reference an iOS-only property inside a macOS block or vice versa
+
+3. **Platform-specific APIs**
+   - `NSColor` is macOS-only, use `UIColor` for iOS
+   - `UINavigationController` is iOS-only
+   - Some SwiftUI modifiers are platform-specific (e.g., `.navigationBarTitleDisplayMode` is iOS-only)
+   - Always wrap platform-specific code in appropriate `#if os()` blocks
+
+4. **View Modifiers**
+   - When creating view modifiers that behave differently per platform, use `#if os(macOS)` / `#else` patterns
+   - See `iOSContentViewAdjustmentsView.swift` and `GlassEffectModifier.swift` for examples
+
+5. **Availability checks**
+   - Use `#available(iOS X.X, *)` and `#available(macOS X.X, *)` for version-specific APIs
+   - When using both, combine them: `if #available(iOS 26.0, *), #available(macOS 26.0, *)`
+
+### Code Review Checklist
+
+Before completing any code change, verify:
+
+- [ ] No iOS-only variables/types are referenced in `#if os(macOS)` blocks
+- [ ] No macOS-only variables/types are referenced in `#if os(iOS)` blocks
+- [ ] Platform-specific UI code is properly wrapped in conditional compilation
+- [ ] New features work conceptually on both platforms (even if UI differs)
+
+### Common Patterns in This Codebase
+
+```swift
+// Color that works on both platforms
+private var backgroundColor: Color {
+#if os(macOS)
+    Color(nsColor: NSColor.windowBackgroundColor)
+#else
+    Color(uiColor: UIColor.secondarySystemBackground)
+#endif
+}
+
+// View that returns different content per platform
+private var macOSContentView: some View {
+#if os(macOS)
+    // macOS-specific implementation
+#else
+    EmptyView()
+#endif
+}
+
+// Toolbar placement that differs per platform
+.toolbar {
+#if os(macOS)
+    ToolbarItem {
+        Button("Done") { /* ... */ }
+    }
+#else
+    ToolbarItem(placement: .topBarTrailing) {
+        Button("Done") { /* ... */ }
+    }
+#endif
+}
+```
+
+### File Structure
+
+- `ContentView.swift` - Main view with both iOS and macOS implementations
+- `iOSContentViewAdjustmentsView.swift` - iOS-specific view adjustments (no-op on macOS)
+- Platform-specific modifiers should follow the pattern of returning `content` unchanged on unsupported platforms

--- a/Pápia/ContentView.swift
+++ b/Pápia/ContentView.swift
@@ -77,7 +77,7 @@ struct ContentView: View {
                 SearchContentUnavailableView(
                     searchResultsCount: model.filteredSearchResults.count,
                     searchText: model.searchText,
-                    searchIsFocused: $searchIsFocused,
+                    searchIsFocused: $searchFocused,
                     searchHistoryItems: [],
                     showSettings: $showSettings
                 )
@@ -119,7 +119,7 @@ struct ContentView: View {
             iOSContentViewAdjustmentsView(
                 searchResultsCount: model.filteredSearchResults.count,
                 searchText: model.searchText,
-                searchIsFocused: $searchIsFocused,
+                searchIsFocused: $searchFocused,
                 searchHistoryItems: [],
                 showSettings: $showSettings
             )


### PR DESCRIPTION
Fix macOS build by correcting `@FocusState` reference and add `.cursorrules` for cross-platform consistency.

The macOS build failed because the `#if os(macOS)` block in `ContentView.swift` incorrectly referenced the iOS-specific `$searchIsFocused` `@FocusState` property instead of the macOS-specific `$searchFocused`. This PR corrects these references and introduces a `.cursorrules` file to guide future cross-platform development.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3a82cb8-0b97-4363-ab55-98013607a0e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3a82cb8-0b97-4363-ab55-98013607a0e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

