### PR TITLE
Ios crash on clear

### DIFF
--- a/PápiaUITests/Pa_piaUITests.swift
+++ b/PápiaUITests/Pa_piaUITests.swift
@@ -87,4 +87,41 @@ final class Pa_piaUITests: XCTestCase {
             }
         }
     }
+
+    /// Test that pressing a toolbar button after clearing the search input does not crash
+    /// This tests for a bug where stale TextSelection indices would cause an index out of bounds crash
+    func testToolbarButtonAfterClearDoesNotCrash() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Add some characters using the toolbar buttons
+        let questionMarkButton = app.buttons["? any"].firstMatch
+        questionMarkButton.tap()
+        questionMarkButton.tap()
+        questionMarkButton.tap()
+
+        // Verify text was added
+        let searchInput = app.textFields["search-input"].firstMatch
+        XCTAssertEqual(searchInput.value as? String, "???", "Expected search input to contain \"???\"")
+
+        // Clear the input using the clear button
+        let clearButton = app.buttons["xmark"].firstMatch
+        XCTAssertTrue(clearButton.waitForExistence(timeout: 2), "Clear button should exist")
+        clearButton.tap()
+
+        // Verify input is cleared
+        XCTAssertEqual(searchInput.value as? String, "", "Expected search input to be empty after clear")
+
+        // Now tap a toolbar button again - this should NOT crash
+        // The bug was that stale TextSelection indices from the previous text would cause a crash
+        let asteriskButton = app.buttons["* many"].firstMatch
+        asteriskButton.tap()
+
+        // Verify the character was added successfully
+        XCTAssertEqual(searchInput.value as? String, "*", "Expected search input to contain \"*\" after pressing toolbar button")
+
+        // Tap another button to make sure it continues to work
+        questionMarkButton.tap()
+        XCTAssertEqual(searchInput.value as? String, "*?", "Expected search input to contain \"*?\"")
+    }
 }


### PR DESCRIPTION
Fix crash when pressing a toolbar button after clearing the search input and add a UI test.

The crash occurred because `searchTextSelection` retained stale indices after the `searchText` was cleared. When `insertLabel()` was subsequently called, it attempted to use these invalid indices on an empty string, leading to an index out of bounds error.

---
<a href="https://cursor.com/background-agent?bcId=bc-c51e7f5f-6b8b-4374-9c4d-8b4550478f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c51e7f5f-6b8b-4374-9c4d-8b4550478f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

