### PR TITLE
Search history navigation

### DIFF
--- a/Pápia/ContentView.swift
+++ b/Pápia/ContentView.swift
@@ -109,9 +109,7 @@ struct ContentView: View {
             }
         }
         .onSubmit(of: .search, {
-            var newHistory = Set(state.searchHistory)
-            newHistory.insert(model.searchText)
-            state.searchHistory = Array(newHistory)
+            state.recordSearchText(model.searchText)
         })
         .searchFocused($searchFocused)
         .task {
@@ -233,6 +231,9 @@ struct ContentView: View {
                             .focused($searchIsFocused)
                             .environmentObject(model)
                             .defaultFocus($searchIsFocused, true)
+                            .onSubmit {
+                                state.recordSearchText(model.searchText)
+                            }
                             .accessibilityLabel("search-input")
                     }
                     .padding(8)

--- a/Pápia/Model/InterfaceState.swift
+++ b/Pápia/Model/InterfaceState.swift
@@ -11,6 +11,7 @@ class InterfaceState: ObservableObject {
     // Nothing selected by default.
     @Published var selection: DataMuseWord?
     @CodableAppStorage("search-history") var searchHistory: [String] = []
+    @Published private(set) var searchHistoryIndex: Int? = nil
     @CodableAppStorage("navigation-history") var navigationHistory: [DataMuseWord] = []
 
     @Published var navigation: [DataMuseWord] = [] {
@@ -33,5 +34,74 @@ class InterfaceState: ObservableObject {
         if navigationHistory.count > 15 {
             navigationHistory.remove(at: 0)
         }
+    }
+
+    var canGoBackInSearchHistory: Bool {
+        if searchHistory.isEmpty {
+            return false
+        }
+        guard let index = searchHistoryIndex else {
+            return true
+        }
+        return index > 0
+    }
+
+    var canGoForwardInSearchHistory: Bool {
+        guard let index = searchHistoryIndex else {
+            return false
+        }
+        return index + 1 < searchHistory.count
+    }
+
+    func recordSearchText(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return
+        }
+
+        var history = searchHistory
+        if let index = searchHistoryIndex, index + 1 < history.count {
+            history.removeSubrange((index + 1)..<history.count)
+        }
+
+        if let existingIndex = history.firstIndex(of: trimmed) {
+            history.remove(at: existingIndex)
+        }
+
+        history.append(trimmed)
+        searchHistory = history
+        searchHistoryIndex = history.count - 1
+    }
+
+    func goBackInSearchHistory() -> String? {
+        guard !searchHistory.isEmpty else {
+            return nil
+        }
+
+        if let index = searchHistoryIndex {
+            guard index > 0 else {
+                return nil
+            }
+            let newIndex = index - 1
+            searchHistoryIndex = newIndex
+            return searchHistory[newIndex]
+        }
+
+        let lastIndex = searchHistory.count - 1
+        searchHistoryIndex = lastIndex
+        return searchHistory[lastIndex]
+    }
+
+    func goForwardInSearchHistory() -> String? {
+        guard let index = searchHistoryIndex else {
+            return nil
+        }
+
+        let newIndex = index + 1
+        guard newIndex < searchHistory.count else {
+            return nil
+        }
+        searchHistoryIndex = newIndex
+        return searchHistory[newIndex]
     }
 }

--- a/Pápia/ToolbarButtonsGroup.swift
+++ b/Pápia/ToolbarButtonsGroup.swift
@@ -28,6 +28,8 @@ import SwiftUI
 
 struct ToolbarButtonsGroup: View {
     @State private var presentedExplainer: String?
+    @EnvironmentObject private var model: DataMuseViewModel
+    @EnvironmentObject private var state: InterfaceState
 
     private func showExplainer(_ text: String) {
         withAnimation {
@@ -38,6 +40,12 @@ struct ToolbarButtonsGroup: View {
                 presentedExplainer = text
             }
         }
+    }
+
+    private func applySearchText(_ text: String) {
+        model.searchText = text
+        let endIndex = text.endIndex
+        model.searchTextSelection = TextSelection(insertionPoint: endIndex)
     }
     
     var body: some View {
@@ -51,6 +59,36 @@ struct ToolbarButtonsGroup: View {
             }
 
             HStack(alignment: .center, spacing: 4) {
+                HStack(spacing: 4) {
+                    Button {
+                        if let previous = state.goBackInSearchHistory() {
+                            applySearchText(previous)
+                        }
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .imageScale(.medium)
+                    }
+                    .frame(width: 36, height: 36)
+                    .modifier(PrimaryButtonModifier())
+                    .disabled(!state.canGoBackInSearchHistory)
+                    .help("Previous search")
+                    .accessibilityLabel("Previous search")
+
+                    Button {
+                        if let next = state.goForwardInSearchHistory() {
+                            applySearchText(next)
+                        }
+                    } label: {
+                        Image(systemName: "chevron.right")
+                            .imageScale(.medium)
+                    }
+                    .frame(width: 36, height: 36)
+                    .modifier(PrimaryButtonModifier())
+                    .disabled(!state.canGoForwardInSearchHistory)
+                    .help("Next search")
+                    .accessibilityLabel("Next search")
+                }
+                .padding(.trailing, 8)
 //                Spacer()
                 ToolbarButtonComponent(
                     label: "*",
@@ -103,5 +141,7 @@ struct ToolbarButtonsGroup: View {
 
 #Preview {
     ToolbarButtonsGroup()
+        .environmentObject(DataMuseViewModel())
+        .environmentObject(InterfaceState())
         .scenePadding()
 }


### PR DESCRIPTION
Add back and forward buttons to the toolbar for navigating previous search queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5ef262f-6f9e-4bcf-ad7f-25ac27a98137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5ef262f-6f9e-4bcf-ad7f-25ac27a98137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

